### PR TITLE
New parameters writeInitialWilsonLines and shiftConstituentQuarkProtonOrigin to save generated initial Wilson lines and control if the center of mass is moved to the origin, consistently support any number of constituent quarks

### DIFF
--- a/input
+++ b/input
@@ -11,6 +11,7 @@ g 1.
 BG 4
 BGq 0.25
 useConstituentQuarkProton 0
+shiftConstituentQuarkProtonOrigin 1
 runningCoupling 0
 muZero 0.3
 c 0.2

--- a/input
+++ b/input
@@ -55,5 +55,6 @@ etaSizeOutput 1
 detaOutput 0
 writeOutputs 1
 writeEvolution 0
+writeInitialWilsonLines 0
 EndOfFile
 

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -636,19 +636,19 @@ void Init::setColorChargeDensity(Lattice *lat, Parameters *param, Random *random
   double nucleiInAverage;
   nucleiInAverage = static_cast<double>(param->getAverageOverNuclei());
 
-  double gaussA[A1][3];
-  double gaussB[A2][3];
+  double gaussA[A1][param->getUseConstituentQuarkProton()];
+  double gaussB[A2][param->getUseConstituentQuarkProton()];
 
   for (int i = 0; i<A1; i++) 
     {
-      for (int iq = 0; iq<3; iq++) 
+      for (int iq = 0; iq<param->getUseConstituentQuarkProton(); iq++) 
 	{
 	  gaussA[i][iq]=1.;
 	}
     }    
   for (int i = 0; i<A2; i++) 
     {
-      for (int iq = 0; iq<3; iq++) 
+      for (int iq = 0; iq<param->getUseConstituentQuarkProton(); iq++) 
 	{
 	  gaussB[i][iq]=1.;
 	}    
@@ -661,7 +661,7 @@ void Init::setColorChargeDensity(Lattice *lat, Parameters *param, Random *random
 	{
 	  for (int i = 0; i<A1; i++) 
 	    {
-	      for (int iq = 0; iq<3; iq++) 
+	      for (int iq = 0; iq<param->getUseConstituentQuarkProton(); iq++) 
 		{
 		  gaussA[i][iq] = (exp(random->Gauss(0,param->getSmearingWidth())))/1.13; // dividing by 1.13 restores the same mean Q_s 
 		  //cout << i << " " << iq << " " << gaussA[i][iq] << endl; 
@@ -674,7 +674,7 @@ void Init::setColorChargeDensity(Lattice *lat, Parameters *param, Random *random
 	{
 	  for (int i = 0; i<A2; i++) 
 	    {
-	      for (int iq = 0; iq<3; iq++) 
+	      for (int iq = 0; iq<param->getUseConstituentQuarkProton(); iq++) 
 		{
 		  gaussB[i][iq] = (exp(random->Gauss(0,param->getSmearingWidth())))/1.13;
 		  

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -635,9 +635,13 @@ void Init::setColorChargeDensity(Lattice *lat, Parameters *param, Random *random
   int count2 = 0;
   double nucleiInAverage;
   nucleiInAverage = static_cast<double>(param->getAverageOverNuclei());
-
-  double gaussA[A1][param->getUseConstituentQuarkProton()];
-  double gaussB[A2][param->getUseConstituentQuarkProton()];
+ 
+  // Arrays to store Q_s fluctuations
+  // Make sure that array size is always at least 1 
+  unsigned int len_quark_array=param->getUseConstituentQuarkProton();
+  if (len_quark_array==0) len_quark_array=1;
+  double gaussA[A1][len_quark_array];
+  double gaussB[A2][len_quark_array];
 
   for (int i = 0; i<A1; i++) 
     {
@@ -671,7 +675,10 @@ void Init::setColorChargeDensity(Lattice *lat, Parameters *param, Random *random
 	{
 	  for (int i = 0; i<A1; i++) 
 	    {
-	      for (int iq = 0; iq<param->getUseConstituentQuarkProton(); iq++) 
+              // Note: len_quark_array is the number of constituent quarks if useConstituentQuarkProton>0, and 1, if 
+              // fluctuations are not included. This way Q_s fluctuations can be implemented for each nucleon even
+              // if useConstituentQuarkProton=0
+	      for (int iq = 0; iq<len_quark_array; iq++) 
 		{
 		  gaussA[i][iq] = (exp(random->Gauss(0,param->getSmearingWidth())))/1.13; // dividing by 1.13 restores the same mean Q_s 
 		  //cout << i << " " << iq << " " << gaussA[i][iq] << endl; 
@@ -684,7 +691,7 @@ void Init::setColorChargeDensity(Lattice *lat, Parameters *param, Random *random
 	{
 	  for (int i = 0; i<A2; i++) 
 	    {
-	      for (int iq = 0; iq<param->getUseConstituentQuarkProton(); iq++) 
+	      for (int iq = 0; iq<len_quark_array; iq++) 
 		{
 		  gaussB[i][iq] = (exp(random->Gauss(0,param->getSmearingWidth())))/1.13;
 		  
@@ -777,8 +784,8 @@ void Init::setColorChargeDensity(Lattice *lat, Parameters *param, Random *random
   //  cout << "BG=" << BG << endl;
 
 
-  double xq[A1][param->getUseConstituentQuarkProton()], xq2[A2][param->getUseConstituentQuarkProton()];
-  double yq[A1][param->getUseConstituentQuarkProton()], yq2[A2][param->getUseConstituentQuarkProton()];
+  double xq[A1][len_quark_array], xq2[A2][len_quark_array];
+  double yq[A1][len_quark_array], yq2[A2][len_quark_array];
   double avgxq=0.;
   double avgyq=0.;
 
@@ -859,6 +866,7 @@ void Init::setColorChargeDensity(Lattice *lat, Parameters *param, Random *random
 	  y = -L/2.+a*iy;
 	   
 	  localpos = ix*N+iy;
+
 	
 	  // nucleus A 
 	  lat->cells[localpos]->setTpA(0.);
@@ -884,7 +892,6 @@ void Init::setColorChargeDensity(Lattice *lat, Parameters *param, Random *random
 
 		  bp2 = (xm-x)*(xm-x)+(ym-y)*(ym-y) + xi*pow((xm-x)*cos(phi) + (ym-y)*sin(phi),2.);
 		  bp2 /= hbarc*hbarc;     	  
-		  
 		  T = sqrt(1+xi)*exp(-bp2/(2.*BG))/(2.*PI*BG)*gaussA[i][0]; // T_p in this cell for the current nucleon
 		}
 

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -641,17 +641,27 @@ void Init::setColorChargeDensity(Lattice *lat, Parameters *param, Random *random
 
   for (int i = 0; i<A1; i++) 
     {
-      for (int iq = 0; iq<param->getUseConstituentQuarkProton(); iq++) 
-	{
-	  gaussA[i][iq]=1.;
-	}
-    }    
+      if (param->getUseConstituentQuarkProton()>0)
+      {
+        for (int iq = 0; iq<param->getUseConstituentQuarkProton(); iq++) 
+	  {
+	    gaussA[i][iq]=1.;
+	  }
+      }
+      else
+        gaussA[i][0]=1.; 
+   }    
   for (int i = 0; i<A2; i++) 
     {
-      for (int iq = 0; iq<param->getUseConstituentQuarkProton(); iq++) 
-	{
-	  gaussB[i][iq]=1.;
-	}    
+      if (param->getUseConstituentQuarkProton()>0)
+      {
+        for (int iq = 0; iq<param->getUseConstituentQuarkProton(); iq++) 
+	  {
+	    gaussB[i][iq]=1.;
+	  }
+      }
+      else
+        gaussB[i][0]=1.; 
     }
   
   // let the log fluctuate

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -793,8 +793,11 @@ void Init::setColorChargeDensity(Lattice *lat, Parameters *param, Random *random
           // that paper can't be used if this is done
 	  for (int iq=0; iq<param->getUseConstituentQuarkProton(); iq++)
 	    {
-	      xq[i][iq] -= avgxq/param->getUseConstituentQuarkProton();
-	      yq[i][iq] -= avgyq/param->getUseConstituentQuarkProton();
+              if (param->getShiftConstituentQuarkProtonOrigin())
+              {
+	          xq[i][iq] -= avgxq/param->getUseConstituentQuarkProton();
+	          yq[i][iq] -= avgyq/param->getUseConstituentQuarkProton();
+              }
 	    }
 	}
     }
@@ -819,8 +822,11 @@ void Init::setColorChargeDensity(Lattice *lat, Parameters *param, Random *random
           // Move center of mass to the origin, see comment above
 	  for (int iq=0; iq<param->getUseConstituentQuarkProton(); iq++)
 	    {
-	      xq2[i][iq] -= avgxq/param->getUseConstituentQuarkProton();
-	      yq2[i][iq] -= avgyq/param->getUseConstituentQuarkProton();
+              if (param->getShiftConstituentQuarkProtonOrigin())
+              {
+	          xq2[i][iq] -= avgxq/param->getUseConstituentQuarkProton();
+	          yq2[i][iq] -= avgyq/param->getUseConstituentQuarkProton();
+              }
 	    }
 	}
     }

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -1562,47 +1562,51 @@ void Init::setV(Lattice *lat, Group* group, Parameters *param, Random* random, G
   
         
   // // output U
-  // stringstream strVOne_name;
-  // strVOne_name << "V1-" << param->getMPIRank() << ".txt";
-  // string VOne_name;
-  // VOne_name = strVOne_name.str();
+  if (param->getWriteInitialWilsonLines())
+  {
+   stringstream strVOne_name;
+   //strVOne_name << "V1-" << param->getMPIRank() << ".txt";
+   strVOne_name << "V-" <<  param->getMPIRank() + 2*param->getSeed()*param->getMPISize() << ".txt";
+   string VOne_name;
+   VOne_name = strVOne_name.str();
 
-  // ofstream foutU(VOne_name.c_str(),ios::out); 
-  // foutU.precision(15);
+   ofstream foutU(VOne_name.c_str(),ios::out); 
+   foutU.precision(15);
 
-  // for(int ix=0; ix<N; ix++)
-  //   {
-  //     for(int iy=0; iy<N; iy++) // loop over all positions
-  // 	{
-  // 	  pos = ix*N+iy;
-  // 	  foutU << ix << " " << iy << " "  << (lat->cells[pos]->getU()).MatrixToString() << endl;
-  // 	}
-  //     foutU << endl;
-  //   }
-  // foutU.close();
+   for(int ix=0; ix<N; ix++)
+     {
+       for(int iy=0; iy<N; iy++) // loop over all positions
+   	{
+   	  int pos = ix*N+iy;
+   	  foutU << ix << " " << iy << " "  << (lat->cells[pos]->getU()).MatrixToString() << endl;
+   	}
+       foutU << endl;
+     }
+   foutU.close();
 
-  // cout<<"wrote " << strVOne_name.str() <<endl;
+   cout<<"wrote " << strVOne_name.str() <<endl;
   
-  // stringstream strVTwo_name;
-  // strVTwo_name << "V2-" << param->getMPIRank() << ".txt";
-  // string VTwo_name;
-  // VTwo_name = strVTwo_name.str();
+   stringstream strVTwo_name;
+   // strVTwo_name << "V2-" << param->getMPIRank() << ".txt";
+   strVTwo_name << "V-" <<  param->getMPIRank() + (1+2*param->getSeed())*param->getMPISize() << ".txt";
+   string VTwo_name;
+   VTwo_name = strVTwo_name.str();
 
-  // ofstream foutU2(VTwo_name.c_str(),ios::out); 
-  // foutU2.precision(15);
-  // for(int ix=0; ix<N; ix++)
-  //   {
-  //     for(int iy=0; iy<N; iy++) // loop over all positions
-  // 	{
-  // 	  pos = ix*N+iy;
-  // 	  foutU2 << ix << " " << iy << " "  << (lat->cells[pos]->getU2()).MatrixToString() << endl;
-  // 	}
-  //     foutU2 << endl;
-  //   }
-  // foutU2.close();
+   ofstream foutU2(VTwo_name.c_str(),ios::out); 
+   foutU2.precision(15);
+   for(int ix=0; ix<N; ix++)
+     {
+       for(int iy=0; iy<N; iy++) // loop over all positions
+   	{
+   	  int pos = ix*N+iy;
+   	  foutU2 << ix << " " << iy << " "  << (lat->cells[pos]->getU2()).MatrixToString() << endl;
+   	}
+       foutU2 << endl;
+     }
+   foutU2.close();
   
-  // cout<<"wrote " << strVTwo_name.str() <<endl;
- 
+   cout<<"wrote " << strVTwo_name.str() <<endl;
+  } 
   // --------
 
 

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -783,15 +783,18 @@ void Init::setColorChargeDensity(Lattice *lat, Parameters *param, Random *random
 	      xq[i][iq] = sqrt(BG*hbarc*hbarc)*random->Gauss();
 	      yq[i][iq] = sqrt(BG*hbarc*hbarc)*random->Gauss();
 	    }
-	  for (int iq=0; iq<3; iq++)
+	  for (int iq=0; iq<param->getUseConstituentQuarkProton(); iq++)
 	    {
 	      avgxq += xq[i][iq];
 	      avgyq += yq[i][iq];
 	    }
-	  for (int iq=0; iq<3; iq++)
+          // Move center of mass to the origin
+          // Note that 1607.01711 this is not done, so parameters quoted in
+          // that paper can't be used if this is done
+	  for (int iq=0; iq<param->getUseConstituentQuarkProton(); iq++)
 	    {
-	      xq[i][iq] -= avgxq/3.;
-	      yq[i][iq] -= avgyq/3.;
+	      xq[i][iq] -= avgxq/param->getUseConstituentQuarkProton();
+	      yq[i][iq] -= avgyq/param->getUseConstituentQuarkProton();
 	    }
 	}
     }
@@ -808,15 +811,16 @@ void Init::setColorChargeDensity(Lattice *lat, Parameters *param, Random *random
 	      yq2[i][iq] = sqrt(BG*hbarc*hbarc)*random->Gauss();
 	    }
 	  
-	  for (int iq=0; iq<3; iq++)
+	  for (int iq=0; iq<param->getUseConstituentQuarkProton(); iq++)
 	    {
 	      avgxq += xq2[i][iq];
 	      avgyq += yq2[i][iq];
 	    }
-	  for (int iq=0; iq<3; iq++)
+          // Move center of mass to the origin, see comment above
+	  for (int iq=0; iq<param->getUseConstituentQuarkProton(); iq++)
 	    {
-	      xq2[i][iq] -= avgxq/3.;
-	      yq2[i][iq] -= avgyq/3.;
+	      xq2[i][iq] -= avgxq/param->getUseConstituentQuarkProton();
+	      yq2[i][iq] -= avgyq/param->getUseConstituentQuarkProton();
 	    }
 	}
     }

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -59,6 +59,7 @@ class Parameters
   double xExponent; // - exponent with which Q_s grows with x (usually 0.31 in IP-Sat for nuclei)
   int writeOutputs; // decide whether to write (1) or not write (0) large output files (like hydro input data)
   int writeEvolution; // decide whether to write (1) or not write (0) time dependent quantities like the anisotropy 
+  int writeInitialWilsonLines; // decide whether to write (1) or not write (0) generated Wilson lines (before any evolution)
   unsigned long long int randomSeed; // stores the random seed used (so the event can be reproduced)
   string NucleusQsTableFileName; // the file name for the table containing Qs^2 as a function of Y and Qs^2(Y=0)
   double BG; // the width of the Gaussian describing the shape of the proton in GeV^(-2)
@@ -284,6 +285,8 @@ class Parameters
   int getWriteOutputs() {return writeOutputs;}
   void setWriteEvolution(int x) {writeEvolution=x;};
   int getWriteEvolution() {return writeEvolution;}
+  void setWriteInitialWilsonLines(int x) {writeInitialWilsonLines=x;}
+  int getWriteInitialWilsonLines(){ return writeInitialWilsonLines; }
   void setNucleonPositionsFromFile(int x) {nucleonPositionsFromFile=x;}
   int getNucleonPositionsFromFile() {return nucleonPositionsFromFile;}
   void setInverseQsForMaxTime(int x) {inverseQsForMaxTime=x;};

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -107,7 +107,7 @@ class Parameters
   int readMultFromFile; // if set, the gluon distribution as a function of k_T is read from file and the integrated rate computed
   double rmax; // radius at which we cut distribution for each nucleon (in fm)
   double protonAnisotropy; //anisotropy of the proton thickness function: xi in Exp[-(x^2 + xi y^2)/2/B]/2/Pi/B Sqrt[xi] - as a first test 
-  int useConstituentQuarkProton; // if 1 use a proton made up of 3 constituent quarks.
+  int useConstituentQuarkProton; // if >0, use proton made up of useConstituentQuarkProton constituent quarks.
   double UVdamp; // UV damping parameter
 
  public:

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -32,7 +32,7 @@ class Parameters
   int useSeedList; // read random seeds from a file if set to (1) - this overwrites the 'use time for seed' setting
   unsigned long long int seed;    // random seed that's added to the current time to generate the full seed (or the full seed, depending on the value of getUseTimeforSeed())
   double ds;   // 'time' step
-  int Ny;      // longitudinal 'resolution' (see Lappi, Eir. Phys. J. C55,285)
+  int Ny;      // longitudinal 'resolution' (see Lappi, Eur. Phys. J. C55,285)
   double g2mu; // g^2 mu
   double Qs;   // Q_s, to be dynamically determined
   int steps;   // number of rapidity steps
@@ -108,6 +108,7 @@ class Parameters
   double rmax; // radius at which we cut distribution for each nucleon (in fm)
   double protonAnisotropy; //anisotropy of the proton thickness function: xi in Exp[-(x^2 + xi y^2)/2/B]/2/Pi/B Sqrt[xi] - as a first test 
   int useConstituentQuarkProton; // if >0, use proton made up of useConstituentQuarkProton constituent quarks.
+  int shiftConstituentQuarkProtonOrigin;  // if 1, move constituent quark center of mass to origin
   double UVdamp; // UV damping parameter
 
  public:
@@ -303,5 +304,7 @@ class Parameters
   int getUsePseudoRapidity() {return usePseudoRapidity;}
   void setUseConstituentQuarkProton(int x) {useConstituentQuarkProton=x;}
   int getUseConstituentQuarkProton() {return useConstituentQuarkProton;}
+  void setShiftConstituentQuarkProtonOrigin(int x) {shiftConstituentQuarkProtonOrigin=x; }
+  int getShiftConstituentQuarkProtonOrigin() { return shiftConstituentQuarkProtonOrigin; }
 };
 #endif // Parameters_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -452,6 +452,7 @@ int readInput(Setup *setup, Parameters *param, int argc, char *argv[], int rank)
   param->setLinearb(setup->IFind(file_name,"samplebFromLinearDistribution"));
   param->setWriteOutputs(setup->IFind(file_name,"writeOutputs"));
   param->setWriteEvolution(setup->IFind(file_name,"writeEvolution"));
+  param->setWriteInitialWilsonLines(setup->IFind(file_name, "writeInitialWilsonLines"));
   param->setAverageOverNuclei(setup->IFind(file_name,"averageOverThisManyNuclei"));
   param->setUseTimeForSeed(setup->IFind(file_name,"useTimeForSeed"));
   param->setUseFixedNpart(setup->IFind(file_name,"useFixedNpart"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -462,6 +462,7 @@ int readInput(Setup *setup, Parameters *param, int argc, char *argv[], int rank)
   param->setReadMultFromFile(setup->IFind(file_name,"readMultFromFile"));
   param->setProtonAnisotropy(setup->DFind(file_name,"protonAnisotropy"));
   param->setUseConstituentQuarkProton(setup->DFind(file_name,"useConstituentQuarkProton"));
+  param->setShiftConstituentQuarkProtonOrigin(setup->DFind(file_name,"shiftConstituentQuarkProtonOrigin"));
   if(rank==0)
     cout << "done." << endl;
 
@@ -488,6 +489,12 @@ int readInput(Setup *setup, Parameters *param, int argc, char *argv[], int rank)
   fout1 << "Ny " << param->getNy() << endl;
   fout1 << "Projectile " << param->getProjectile() << endl;
   fout1 << "Target " << param->getTarget() << endl;
+  if (param->getUseConstituentQuarkProton()>0)
+  {
+    fout1 << "Nucleons consists of " << param->getUseConstituentQuarkProton() << " constituent quarks" << endl;
+    if (param->getShiftConstituentQuarkProtonOrigin())
+      fout1 << "... constituent quark center of mass moved to origin" << endl;
+  }
   fout1 << "Gaussian wounding " << param->getGaussianWounding() << endl;
   fout1 << "Using fluctuating x=Qs/root(s) " << param->getUseFluctuatingx() << endl;
   if( param->getRunWithkt()==0)


### PR DESCRIPTION
If writeInitialWilsonLines it is set to 1, then the code writes generated Wilson lines (before any evolution) to files V-NN.txt
Filenames are generated such that when seed is increased by 1,
then filename numbering continuous from the previous value.

if shiftConstituentQuarkProtonOrigin is 1, then constituent quark center of mass is moved to the origin (like in our PRL fluctuations paper). If 0, hot spots are sampled such that center of mass != origin, like in our fluctuations-PRD.

As in the new version the parameter useConstituentQuarkProton refers to the number of constituent quarks (0=round, >0: sets number of hot spots),  change some references to 3 constituent quarks to any number of constituent quarks